### PR TITLE
fix: unauthenticated error

### DIFF
--- a/twitch/twitch.go
+++ b/twitch/twitch.go
@@ -51,7 +51,7 @@ type Client struct {
 
 // New returns a new twitch API client.
 func New(client *http.Client, clientID string) Client {
-	return Client{client, clientID, "https://gql.twitch.tv/gql", "http://usher.ttvnw.net"}
+	return Client{client, clientID, "https://gql.twitch.tv/gql", "https://usher.ttvnw.net"}
 }
 
 // Custom returns a new twitch API client with custom API endpoints


### PR DESCRIPTION
Fixed an unauthenticated error. Seems like twitch changed something in the http endpoint.
`403 error: http://usher.ttvnw.net/vod/...?nauth={"authorization":{"forbidden":false,"reason":""}...`

The C# TwitchDownloader faced the same issue and it got fixed in this commit:
(lay295/TwitchDownloader@9de9db34eedd0808558463b28b7199261e5d2d3b)

I made the same fix (changed http to https) there is no need to change the complete url scheme (as seen in the comments in the commit)